### PR TITLE
Removed MiddleName property from Author

### DIFF
--- a/src/Application/Dto/AuthorDto.cs
+++ b/src/Application/Dto/AuthorDto.cs
@@ -5,7 +5,6 @@
         public int? Id { get; set; }
         public string FirstName { get; set; }
         public string LastName { get; set; }
-        public string MiddleName { get; set; }
         public bool IsConfirmed { get; set; }
     }
 }

--- a/src/Application/Services/Implementation/AuthorService.cs
+++ b/src/Application/Services/Implementation/AuthorService.cs
@@ -59,8 +59,7 @@ namespace Application.Services.Implementation
         {
             return _mapper.Map<List<AuthorDto>>(await _authorRepository.GetAll()
                                                                  .Where(x => x.FirstName.StartsWith(filter) 
-                                                                     || x.LastName.StartsWith(filter) 
-                                                                     || x.MiddleName.StartsWith(filter))
+                                                                     || x.LastName.StartsWith(filter))
                                                                  .ToListAsync());
         }
 

--- a/src/ApplicationTest/Controllers/AuthorControllerTest.cs
+++ b/src/ApplicationTest/Controllers/AuthorControllerTest.cs
@@ -81,9 +81,9 @@ namespace ApplicationTest.Controllers
         [Test]
         public async Task Add_Author_Returns_ActionResultWithSamePropertyValues()
         {
-            var insertDto = new AuthorDto() {FirstName = "Max", LastName = "Novitskyi", MiddleName = "Yar"};
+            var insertDto = new AuthorDto() {FirstName = "Max", LastName = "Novitskyi"};
             var expectedAuthorDto = new AuthorDto()
-                {Id = 201, FirstName = "Max", LastName = "Novitskyi", MiddleName = "Yar"};
+                {Id = 201, FirstName = "Max", LastName = "Novitskyi"};
             _authorServiceMock.Setup(s => s.Add(It.IsAny<AuthorDto>())).ReturnsAsync(expectedAuthorDto);
 
             var createdAtActionResult = await _authorController.PostAuthor(insertDto);

--- a/src/ApplicationTest/Validators/AuthorValidatorTest.cs
+++ b/src/ApplicationTest/Validators/AuthorValidatorTest.cs
@@ -127,38 +127,5 @@ namespace ApplicationTest.Validators
         }
 
         #endregion
-
-        #region MiddleName
-
-        [Test]
-        public void MiddleName_IsNull_ShouldNotThrowsException()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(author => author.MiddleName, null as string);
-        }
-
-        [Test]
-        public void MiddleName_IsNotNull_ShouldNotThrowException()
-        {
-            _validator.ShouldNotHaveValidationErrorFor(author => author.MiddleName, "John");
-        }
-        [Test]
-        public void MiddleName_MoreThanThirtyCharacters_ThrowsException()
-        {
-            _validator.ShouldHaveValidationErrorFor(author => author.MiddleName, "JohnJohnJohnJohnJohnJohnJohnJohn");
-        }
-
-        [Test, TestCaseSource(nameof(_namesWithForbiddenCharacters))]
-        public void MiddleName_ContainsForbiddenCharacters_ThrowsException(string value)
-        {
-            _validator.ShouldHaveValidationErrorFor(author => author.MiddleName, value);
-        }
-
-        [Test, TestCaseSource(nameof(_namesWithPermittedCharacters))]
-        public void MiddleName_ContainsPermittedCharacters_ShouldNotThrowException(string value)
-        {
-            _validator.ShouldNotHaveValidationErrorFor(author => author.MiddleName, value);
-        }
-
-        #endregion
     }
 }

--- a/src/BookCrossingBackEnd/Controllers/AuthorsController.cs
+++ b/src/BookCrossingBackEnd/Controllers/AuthorsController.cs
@@ -2,11 +2,13 @@
 using Application.Dto;
 using Application.Dto.QueryParams;
 using Application.Services.Interfaces;
+using Domain.RDBMS.Entities;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace BookCrossingBackEnd.Controllers
 {
-    //[Authorize]
+    [Authorize(Roles = "Admin")]
     [Route("api/[controller]")]
     [ApiController]
     public class AuthorsController : ControllerBase
@@ -43,6 +45,7 @@ namespace BookCrossingBackEnd.Controllers
         }
 
         // GET: api/Authors/"Tom"
+        [AllowAnonymous]
         [HttpGet("{filter}")]
         public async Task<ActionResult> GetAuthor(string filter)
         {

--- a/src/BookCrossingBackEnd/Migrations/20200520205207_RemoveAuthorsMiddleName.Designer.cs
+++ b/src/BookCrossingBackEnd/Migrations/20200520205207_RemoveAuthorsMiddleName.Designer.cs
@@ -4,14 +4,16 @@ using Infrastructure.RDBMS;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace BookCrossingBackEnd.Migrations
 {
     [DbContext(typeof(BookCrossingContext))]
-    partial class BookCrossingContextModelSnapshot : ModelSnapshot
+    [Migration("20200520205207_RemoveAuthorsMiddleName")]
+    partial class RemoveAuthorsMiddleName
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/BookCrossingBackEnd/Migrations/20200520205207_RemoveAuthorsMiddleName.cs
+++ b/src/BookCrossingBackEnd/Migrations/20200520205207_RemoveAuthorsMiddleName.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace BookCrossingBackEnd.Migrations
+{
+    public partial class RemoveAuthorsMiddleName : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "middlename",
+                table: "Author");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "middlename",
+                table: "Author",
+                type: "nvarchar(30)",
+                maxLength: 30,
+                nullable: true);
+        }
+    }
+}

--- a/src/BookCrossingBackEnd/ServiceExtension/ServiceExtension.cs
+++ b/src/BookCrossingBackEnd/ServiceExtension/ServiceExtension.cs
@@ -127,7 +127,7 @@ namespace BookCrossingBackEnd.ServiceExtension
         {
             services.AddMvc(options =>
             {
-                options.Filters.Add(new ModelValidationFilter());
+                //options.Filters.Add(new ModelValidationFilter());
             })
           .AddFluentValidation(cfg =>
           {

--- a/src/BookCrossingBackEnd/Validators/AuthorValidator.cs
+++ b/src/BookCrossingBackEnd/Validators/AuthorValidator.cs
@@ -17,10 +17,6 @@ namespace BookCrossingBackEnd.Validators
                 .NotNull()
                 .Length(2, 20)
                 .Matches(@"^([a-zA-Z '-]+)$");
-            RuleFor(x => x.MiddleName)
-                .MaximumLength(30)
-                .Matches(@"&^|^([a-zA-Z '-]+)$")
-                .When(x => !string.IsNullOrWhiteSpace(x.MiddleName));
         }
     }
 }

--- a/src/Domain/RDBMS/Entities/Author.cs
+++ b/src/Domain/RDBMS/Entities/Author.cs
@@ -7,7 +7,6 @@ namespace Domain.RDBMS.Entities
         public int Id { get; set; }
         public string FirstName { get; set; }
         public string LastName { get; set; }
-        public string MiddleName { get; set; }
         public bool IsConfirmed { get; set; }
 
         public virtual List<BookAuthor> BookAuthor { get; set; } 

--- a/src/Infastructure/RDBMS/Configuration/AuthorConfiguration.cs
+++ b/src/Infastructure/RDBMS/Configuration/AuthorConfiguration.cs
@@ -21,11 +21,7 @@ namespace Infrastructure.RDBMS.Configuration
                 .IsRequired()
                 .HasColumnName("lastname")
                 .HasMaxLength(20);
-
-            builder.Property(e => e.MiddleName)
-                .HasColumnName("middlename")
-                .HasMaxLength(30);
-
+            
             builder.Property(e => e.IsConfirmed)
                 .HasColumnName("is_confirmed");
         }       

--- a/src/Infastructure/RDBMS/DataInitializer.cs
+++ b/src/Infastructure/RDBMS/DataInitializer.cs
@@ -33,7 +33,6 @@ namespace Infrastructure.RDBMS
                 context.Author.Add(new Author()
                 {
                     FirstName = "List",
-                    MiddleName = "Superman",
                     LastName = "Ferents",
                     IsConfirmed = true
                 });


### PR DESCRIPTION
- Removed MiddleName from Author(Entity)/AuthorDto/AuthorDtoValidators
- Added migration for removal of MiddleName from DB
- Author controller is now only for Admin, Except the action method for filtering
- Adjusted unit tests that included Author's MiddleName property

Closes #217 